### PR TITLE
change language string report post default value

### DIFF
--- a/widget/assets/js/shared/stringsConfig.js
+++ b/widget/assets/js/shared/stringsConfig.js
@@ -97,7 +97,7 @@ const stringsConfig = {
 				title: "Report Post"
 				, placeholder: "Report Post"
 				, maxLength: 30
-				, defaultValue: "Report Post"
+				, defaultValue: "Report Post and Block User"
 			},
 			deletePost: {
 				title: "Delete Post"


### PR DESCRIPTION
- Community Wall Make the default language string for report post - Report Post and Block User.