### PR TITLE
Ensure mutual blocking hides posts and members on both sides

### DIFF
--- a/widget/app.service.js
+++ b/widget/app.service.js
@@ -291,7 +291,8 @@
                         })
                 },
                 getUsersWhoFollow: function (userId, wallId, cb) {
-                    const blockedUserStrings = SocialItemsInstance.blockedUsers.map(userId => `${userId}-`);
+                    const blockedUserIds = SocialItemsInstance.blockedUsers.concat(SocialItemsInstance.blockedByUsers || []);
+                    const blockedUserStrings = blockedUserIds.map(userId => `${userId}-`);
                     const pageSize = 50;
                     var allUsers = [];
                     let page = 0;
@@ -580,34 +581,38 @@
                 getBlockedUsers: function(callback) {
                     let _this = this;
                     buildfire.auth.getCurrentUser((err, currentUser) => {
-                        if (err) {
-                            callback(err, false)
-                        }
-                        if (currentUser) {
+                        if (err || !currentUser) return callback(err, false);
+
+                        buildfire.publicData.search({
+                            filter: {
+                                $and: [{
+                                    "_buildfire.index.array1.string1": `${currentUser.userId}-`
+                                }, {
+                                    "_buildfire.index.string1": ""
+                                }]
+                            }
+                        }, 'subscribedUsersData', function (err, data) {
+                            if (err) return callback(err, false);
+
+                            let blocked = [];
+                            if (data && data.length > 0 && data[0].data.blockedUsers) {
+                                blocked = data[0].data.blockedUsers;
+                            }
+
                             buildfire.publicData.search({
                                 filter: {
-                                    $and: [{
-                                        "_buildfire.index.array1.string1": `${currentUser.userId}-`
-                                    }, {
-                                        "_buildfire.index.string1": ""
-                                    }]
-                                }
-                            }, 'subscribedUsersData', function (err, data) {
-                                if (err) callback(err, false);
-                                else if (data && data.length > 0) {
-
-                                    if (data[0].data.blockedUsers) {
-                                        callback(null, data[0].data.blockedUsers);
-                                    } else {
-                                        callback(null, []);
-                                    }
+                                    "_buildfire.index.array1.string1": `blockedUser_${currentUser.userId}`
+                                },
+                                pageSize: 50
+                            }, 'subscribedUsersData', function (err2, blockedByData) {
+                                if (!err2 && blockedByData && blockedByData.length > 0) {
+                                    SocialItemsInstance.blockedByUsers = blockedByData.map(item => item.data.userId);
                                 } else {
-                                    callback(err, []);
+                                    SocialItemsInstance.blockedByUsers = [];
                                 }
-                            })
-                        } else {
-                            callback(err, false)
-                        }
+                                callback(null, blocked);
+                            });
+                        })
                     });
                 },
                 getBlockedUsersList: function(options, callback) {
@@ -857,6 +862,7 @@
                 _this.indexingUpdateDone = false;
                 _this.reportData = {};
                 _this.blockedUsers = [];
+                _this.blockedByUsers = [];
                 _this.cachedUserProfiles = {};
             };
             var instance;
@@ -1122,7 +1128,8 @@
             function getFilter() {
                 let filter = {};
 
-                const blockedUserStrings = _this.blockedUsers.map(userId => `createdBy_${userId}`);
+                const blockedUserIds = _this.blockedUsers.concat(_this.blockedByUsers || []);
+                const blockedUserStrings = blockedUserIds.map(userId => `createdBy_${userId}`);
 
                 if (_this.wid === "") {
                     filter = {

--- a/widget/controllers/widget.thread.controller.js
+++ b/widget/controllers/widget.thread.controller.js
@@ -107,13 +107,13 @@
           }
 
           Thread.getDisplayName = (userId, userDetails) => {
-              const blockedUsers = Thread.SocialItems.blockedUsers;
+              const blockedUsers = Thread.SocialItems.blockedUsers.concat(Thread.SocialItems.blockedByUsers || []);
               if (blockedUsers.includes(userId)) return Thread.SocialItems.languages.blockedUser || "Blocked User";
               else return Thread.SocialItems.getUserName(userDetails);
           }
 
           Thread.isBlockedUser = (userId) => {
-              const blockedUsers = Thread.SocialItems.blockedUsers;
+              const blockedUsers = Thread.SocialItems.blockedUsers.concat(Thread.SocialItems.blockedByUsers || []);
               return blockedUsers.includes(userId);
           }
 


### PR DESCRIPTION
## Summary
- Track users who have blocked the current user via publicData search instead of updating their profiles
- Filter members and posts by combining blocked users with those who blocked the viewer
- Hide names and comments from any user involved in a block within threads

## Testing
- `npm test` *(fails: sh: 1: ./node_modules/.bin/karma: not found)*
- `npm install karma` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d74da1e08321b4683b9bffccac5c