### PR TITLE
Add pagination to content home posts

### DIFF
--- a/control/content/templates/home.html
+++ b/control/content/templates/home.html
@@ -26,7 +26,7 @@
         style="overflow-y:auto;" class="infinite-scroll-parent">
         <div class="wrapper social-plugin" infinite-scroll-distance="0"
             data-infinite-container=".infinite-scroll-parent"
-            infinite-scroll="ContentHome.startLoadingPosts"
+            infinite-scroll="ContentHome.startLoadingPosts()"
             infinite-scroll-disabled="ContentHome.noMore">
             <div class="social-item" ng-repeat="post in ContentHome.posts">
                 <div class="head flex align-items-center">


### PR DESCRIPTION
## Summary
- add pagination state management to `ContentHomeCtrl` so post queries request one page at a time
- append additional pages to the existing post list when the infinite scroll handler fires
- update the home template to invoke the new scroll handler so more posts load on demand

## Testing
- npm test *(fails: local `./node_modules/.bin/karma` binary is not generated in this environment)*
- ./node_modules/karma/bin/karma start --single-run --browsers PhantomJS *(fails: PhantomJS launcher and bower-provided assets are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c832a8ff088321ba2750afd1db8a3a