### PR TITLE
Add customizable fallback name and optimize unblocking

### DIFF
--- a/widget/assets/js/shared/stringsConfig.js
+++ b/widget/assets/js/shared/stringsConfig.js
@@ -380,6 +380,12 @@ const stringsConfig = {
 				, placeholder: "No blocked users."
 				, maxLength: 50
 				, defaultValue: "No blocked users."
+			},
+			someone: {
+				title: "Fallback User Name"
+				, placeholder: "Someone"
+				, maxLength: 30
+				, defaultValue: "Someone"
 			}
                 }
         },


### PR DESCRIPTION
## Summary
- add a configurable `someone` label to the language strings and use it as the fallback name in `getUserName`
- cache the current user's subscription record so `unblockUser` can update blocked users without an extra search
- keep blocked user lists in sync after updates by refreshing the cached record

## Testing
- `node node_modules/karma/bin/karma start --single-run --browsers PhantomJS` *(fails: legacy karma setup cannot parse modern syntax and PhantomJS launcher is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c97564134083218506d89c60fdb19a